### PR TITLE
Remove unhelpful sba indices test cases

### DIFF
--- a/tests/test_sequence_collection.py
+++ b/tests/test_sequence_collection.py
@@ -543,14 +543,6 @@ class TestSbaMapping(TestSequenceCollection):
         """
         Verify that an out of bounds index will be caught
         """
-        sba_indices = np.array([-1, 17, 23], dtype=np.uint32)
-        with pytest.raises(ValueError):
-            SequenceCollection._get_opposite_strand_sba_indices(sba_indices, 30)
-
-        sba_indices = np.array([0, 17, -1], dtype=np.uint32)
-        with pytest.raises(ValueError):
-            SequenceCollection._get_opposite_strand_sba_indices(sba_indices, 30)
-
         sba_indices = np.array([30, 17, 23], dtype=np.uint32)
         with pytest.raises(ValueError):
             SequenceCollection._get_opposite_strand_sba_indices(sba_indices, 30)


### PR DESCRIPTION
test_get_opposite_strand_sba_indices_errors() tested whether an exception was raised when an input index was less than zero. However, since the dtype of the input NumPy array is uint32, it is not possible to have a negative number, and -1 merely underflows to 2**32 - 1.  So this test case will be removed since it does not test what was intended.